### PR TITLE
Placelist now displays proper ranking

### DIFF
--- a/client/src/components/Place/Place.js
+++ b/client/src/components/Place/Place.js
@@ -25,10 +25,16 @@ function Place({ placeData, rank }) {
           <span className="place-name">{placeData.name}</span>
         </span>
 
-        <span className="place-rating">
-          <Rate disabled allowHalf defaultValue={rating} />
-          <span className="num-of-reviews">{reviews.length}</span>
-        </span>
+        {reviews.length > 0?
+          <span className="place-rating">
+            <Rate disabled allowHalf defaultValue={rating} />
+            <span className="num-of-reviews">{reviews.length}</span>
+          </span>
+          :
+          <span className="place-rating">
+            <span className="num-of-reviews">No reviews yet</span>
+          </span>
+        }
       </Card>
     </Link>
   );

--- a/client/src/components/Place/Place.js
+++ b/client/src/components/Place/Place.js
@@ -3,32 +3,26 @@ import "./Place.css";
 import { Avatar, Card, Rate } from "antd";
 
 import { Link } from "react-router-dom";
-import { useSelector, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { setPlace } from "../../redux/actions/placeActions"
 
-function Place({ placeData, rank }) {
+function Place({ placeData }) {
   const dispatch = useDispatch();
-  const reviews = useSelector((state) => state.reviews.allReviews)
-    .filter((review) => review.place_id === placeData.place_id);
-
-  const rating = reviews
-        .map((review) => review.rating)
-        .reduce((p, c) => p + c, 0) / reviews.length;
 
   return (
     <Link to="/placeview" onClick={() => dispatch(setPlace(placeData.place_id))} >
       <Card style={{ margin: 16 }}>
         <span className="place">
           <Avatar style={{ color: "#f56a00", backgroundColor: "#fde3cf" }}>
-            {rank}
+            {placeData.rank}
           </Avatar>
           <span className="place-name">{placeData.name}</span>
         </span>
 
-        {reviews.length > 0?
+        {placeData.numReviews > 0?
           <span className="place-rating">
-            <Rate disabled allowHalf defaultValue={rating} />
-            <span className="num-of-reviews">{reviews.length}</span>
+            <Rate disabled allowHalf defaultValue={placeData.avgRating} />
+            <span className="num-of-reviews">{placeData.numReviews}</span>
           </span>
           :
           <span className="place-rating">

--- a/client/src/components/PlaceList/PlaceList.js
+++ b/client/src/components/PlaceList/PlaceList.js
@@ -26,7 +26,7 @@ function PlaceList() {
         .filter((review) => review.place_id === place.place_id)
         .map((review) => review.rating)
         .reduce((p, c) => p + c, 0) / reviews.filter((review) => review.place_id === place.place_id).length}))
-    .sort((place1, place2) => place2.avgRating - place1.avgRating);
+    .sort((place1, place2) => (place2.avgRating? place2.avgRating : 0) - (place1.avgRating? place1.avgRating : 0));
 
   const ratings = new Set(currentPlaces.map((place) => place.avgRating));
   const ratingsSorted = Array.from(ratings).sort((rating1, rating2) => rating2 - rating1);

--- a/client/src/components/PlaceList/PlaceList.js
+++ b/client/src/components/PlaceList/PlaceList.js
@@ -25,9 +25,21 @@ function PlaceList() {
         .reduce((p, c) => p + c, 0) / reviews.filter((review) => review.place_id === place.place_id).length}))
         .sort((place1, place2) => place2.avgRating - place1.avgRating);
 
+
+  currentPlaces = currentPlaces
+    .map(place => ({ ...place, ranking: 55}));
+
+  let ratings = new Set(currentPlaces.map((place) => place.avgRating));
+  let ratingsSorted = Array.from(ratings).sort((rating1, rating2) => rating2 - rating1);
+  currentPlaces = currentPlaces
+    .map(place => ({ ...place, ranking: ratingsSorted.indexOf(place.avgRating) + 1}));
+
+  currentPlaces = currentPlaces
+    .map(place => ({...place, ranking: place.ranking == 0? "?" : place.ranking}));
+  //TODO: just bring in average rating as calculated here...
   let placeList = currentPlaces.map(
     (placeData) => (
-      <Place key={placeData.place_id} placeData={placeData} rank = {currentPlaces.indexOf(placeData) + 1} />
+      <Place key={placeData.place_id} placeData={placeData} rank = {placeData.ranking} />
     )
   );
   return (

--- a/client/src/components/PlaceList/PlaceList.js
+++ b/client/src/components/PlaceList/PlaceList.js
@@ -19,27 +19,26 @@ function PlaceList() {
 
   currentPlaces = currentPlaces
     .map(place => ({ ...place,
+      numReviews: reviews
+      .filter((review) => review.place_id === place.place_id)
+      .length,
       avgRating:  reviews
         .filter((review) => review.place_id === place.place_id)
         .map((review) => review.rating)
         .reduce((p, c) => p + c, 0) / reviews.filter((review) => review.place_id === place.place_id).length}))
-        .sort((place1, place2) => place2.avgRating - place1.avgRating);
+    .sort((place1, place2) => place2.avgRating - place1.avgRating);
 
+  const ratings = new Set(currentPlaces.map((place) => place.avgRating));
+  const ratingsSorted = Array.from(ratings).sort((rating1, rating2) => rating2 - rating1);
+  currentPlaces = currentPlaces
+    .map(place => ({ ...place, rank: ratingsSorted.indexOf(place.avgRating) + 1}));
 
   currentPlaces = currentPlaces
-    .map(place => ({ ...place, ranking: 55}));
+    .map(place => ({...place, rank: place.rank == 0? "?" : place.rank}));
 
-  let ratings = new Set(currentPlaces.map((place) => place.avgRating));
-  let ratingsSorted = Array.from(ratings).sort((rating1, rating2) => rating2 - rating1);
-  currentPlaces = currentPlaces
-    .map(place => ({ ...place, ranking: ratingsSorted.indexOf(place.avgRating) + 1}));
-
-  currentPlaces = currentPlaces
-    .map(place => ({...place, ranking: place.ranking == 0? "?" : place.ranking}));
-  //TODO: just bring in average rating as calculated here...
-  let placeList = currentPlaces.map(
+  const placeList = currentPlaces.map(
     (placeData) => (
-      <Place key={placeData.place_id} placeData={placeData} rank = {placeData.ranking} />
+      <Place key={placeData.place_id} placeData={placeData} />
     )
   );
   return (

--- a/client/src/components/PlaceList/PlaceList.js
+++ b/client/src/components/PlaceList/PlaceList.js
@@ -34,7 +34,7 @@ function PlaceList() {
     .map(place => ({ ...place, rank: ratingsSorted.indexOf(place.avgRating) + 1}));
 
   currentPlaces = currentPlaces
-    .map(place => ({...place, rank: place.rank == 0? "?" : place.rank}));
+    .map(place => ({...place, rank: place.rank === 0? "?" : place.rank}));
 
   const placeList = currentPlaces.map(
     (placeData) => (


### PR DESCRIPTION
PlaceList rankings now display properly, with the same number given to places with tied scores:

![Screenshot (509)](https://user-images.githubusercontent.com/30274095/123486437-db9f0100-d5c0-11eb-897a-f6ab25003f10.png)

Places with no scores display at the bottom of the list with rank number replaced by a "?" and average rating stars replaced by "No reviews yet" text 