### PR TITLE
Categorylist now displays correct place number

### DIFF
--- a/client/src/components/CategoryList/CategoryList.js
+++ b/client/src/components/CategoryList/CategoryList.js
@@ -17,11 +17,13 @@ function CategoryList() {
 
   let categories = useSelector((state) => state.categories.allCategories);
   const places = useSelector((state) => state.places.allPlaces);
+  const currentGroupID = useSelector((state) => state.groups.currentGroupID);
 
   categories = categories
     .map(category => ({...category,
       numPlaces: places
-        .filter((place) => place.category_id === category.category_id)
+        .filter((place) => (place.category_id === category.category_id)
+          && (place.group_id === currentGroupID))
         .length
     }));
 


### PR DESCRIPTION
CategoryList wasn't filtering place counts by group, which led to incorrect place counts.
It now filters to only count places in the current group, which means the place count it displays now matches the place count on the page you click through to.

![category-filter-places](https://user-images.githubusercontent.com/30274095/124669388-26ddcd00-de67-11eb-9132-9718bf0cd1a2.gif)
