### PR TITLE
PlaceList now loads reviews from database

### DIFF
--- a/client/src/components/PlaceList/PlaceList.js
+++ b/client/src/components/PlaceList/PlaceList.js
@@ -5,12 +5,14 @@ import { useDispatch, useSelector } from "react-redux";
 import { useEffect } from "react";
 
 import { getPlaces } from "../../redux/actions/placeActions";
+import { getReviews } from "../../redux/actions/reviewActions";
 
 function PlaceList() {
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(getPlaces());
+    dispatch(getReviews());
   }, [dispatch]);
 
   const places = useSelector((state) => state.places.allPlaces);


### PR DESCRIPTION
PlaceList was not loading reviews from database, leading to a display of 0 reviews for all places until the user navigated to a PlaceView page and then back again.

This now gets reviews from database right on CategoryView/PlaceList.

![categoryview-has-reviews](https://user-images.githubusercontent.com/30274095/124806571-b344ca00-df11-11eb-9dc5-8fe6701e31ee.gif)
