### PR TITLE
Request view frontend

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,6 +15,7 @@ import CategoryView from "./components/CategoryView/CategoryView";
 import CreateGroup from "./components/CreateGroup/CreateGroup";
 import GroupListView from "./components/GroupListView/GroupListView";
 import GroupView from "./components/GroupView/GroupView";
+import RequestView from "./components/RequestView/RequestView";
 import { Layout } from "antd";
 import Login from "./components/Login/Login";
 import MobileNavBar from "./components/Navigation/MobileNavBar/MobileNavBar";
@@ -64,6 +65,7 @@ function App() {
               <PrivateRoute exact path="/addplace" component={AddPlace} />
               <PrivateRoute exact path="/placeview" component={PlaceView} />
               <PrivateRoute exact path="/addreview" component={AddReview} />
+              <PrivateRoute exact path="/requestview" component={RequestView} />
             </Switch>
           </Content>
           <Footer style={{ textAlign: "center" }}>

--- a/client/src/components/Navigation/NavBar/NavBar.js
+++ b/client/src/components/Navigation/NavBar/NavBar.js
@@ -80,7 +80,7 @@ function NavBar(props) {
         <Link to="/addreview">Add Review</Link>
       </Menu.Item>
       <Menu.Item key="requestView" icon={<BellOutlined />}>
-        <Link to="/requestview">Request View</Link>
+        <Link to="/requestview">Requests</Link>
       </Menu.Item>
       <Menu.Item onClick={handleLogout} key="logout" icon={<LogoutOutlined />}>
         <Link to="/login">Log Out</Link>

--- a/client/src/components/Navigation/NavBar/NavBar.js
+++ b/client/src/components/Navigation/NavBar/NavBar.js
@@ -8,6 +8,7 @@ import {
   ShopOutlined,
   TeamOutlined,
   UsergroupAddOutlined,
+  BellOutlined
 } from "@ant-design/icons";
 import { useEffect, useState } from "react";
 
@@ -50,6 +51,9 @@ function NavBar(props) {
     if (path === "/addreview") {
       setTab("addReview");
     }
+    if (path === "/requestview") {
+      setTab("requestView");
+    }
   }, [path]);
 
   return (
@@ -74,6 +78,9 @@ function NavBar(props) {
       </Menu.Item>
       <Menu.Item key="addReview" icon={<FileAddOutlined />}>
         <Link to="/addreview">Add Review</Link>
+      </Menu.Item>
+      <Menu.Item key="requestView" icon={<BellOutlined />}>
+        <Link to="/requestview">RequestView</Link>
       </Menu.Item>
       <Menu.Item onClick={handleLogout} key="logout" icon={<LogoutOutlined />}>
         <Link to="/login">Logout</Link>

--- a/client/src/components/Navigation/NavBar/NavBar.js
+++ b/client/src/components/Navigation/NavBar/NavBar.js
@@ -80,10 +80,10 @@ function NavBar(props) {
         <Link to="/addreview">Add Review</Link>
       </Menu.Item>
       <Menu.Item key="requestView" icon={<BellOutlined />}>
-        <Link to="/requestview">RequestView</Link>
+        <Link to="/requestview">Request View</Link>
       </Menu.Item>
       <Menu.Item onClick={handleLogout} key="logout" icon={<LogoutOutlined />}>
-        <Link to="/login">Logout</Link>
+        <Link to="/login">Log Out</Link>
       </Menu.Item>
     </Menu>
   );

--- a/client/src/components/Request/Request.css
+++ b/client/src/components/Request/Request.css
@@ -1,0 +1,10 @@
+.user-name {
+  margin: 2px;
+  font-size: large;
+  font-weight: bold;
+}
+
+.group-name {
+  font-size: large;
+  font-weight: bold;
+}

--- a/client/src/components/Request/Request.js
+++ b/client/src/components/Request/Request.js
@@ -1,0 +1,28 @@
+import "./Request.css";
+
+import { Avatar, Card, Button } from "antd";
+import { CheckOutlined, StopOutlined } from "@ant-design/icons";
+
+function Request(props) {
+  return (
+    <Card style={{ margin: 16 }}>
+      <Avatar src={props.user.avatarURL} size={64} />
+      {props.user.name + " wants to join " + props.group.name}
+      <Avatar src={props.group.avatarURL} size={64} />
+      <Button
+        icon={<CheckOutlined size="large" />}
+        size="medium"
+      >
+        Accept
+      </Button>
+      <Button
+        icon={<StopOutlined size="large" />}
+        size="medium"
+      >
+        Reject
+      </Button>
+    </Card>
+  );
+}
+
+export default Request;

--- a/client/src/components/Request/Request.js
+++ b/client/src/components/Request/Request.js
@@ -6,31 +6,50 @@ import { CheckOutlined, StopOutlined } from "@ant-design/icons";
 function Request(props) {
   return (
     <Card style={{ margin: 16 }}>
-      <Row align="middle" justify="space-around">
-        <Col>
-          <Avatar src={props.user.avatarURL} size={64} />
-          {props.user.name}
+      <Row align="middle" justify="end">
+        <Col span={8}>
+          <Row align="middle">
+            <Col flex="70px">
+              <Avatar src={props.user.avatarURL} size={64} />
+            </Col>
+            <Col flex="auto">
+              <div className="user-name">{props.user.name}</div>
+              <div className="wants-to-join">{" wants to join "}</div>
+            </Col>
+          </Row>
         </Col>
-        <Col>
-          {" wants to join "}
+        <Col span={8}>
+          <Row align="middle">
+            <Col flex="70px">
+              <Avatar src={props.group.avatarURL} size={64} />
+            </Col>
+            <Col flex="auto">
+              <div className="group-name">{props.group.name}</div>
+            </Col>
+          </Row>
         </Col>
-        <Col>
-          {props.group.name}
-          <Avatar src={props.group.avatarURL} size={64} />
-        </Col>
-        <Col>
-          <Button
-            icon={<CheckOutlined size="large" />}
-            size="medium"
-          >
-            Accept
-          </Button>
-          <Button
-            icon={<StopOutlined size="large" />}
-            size="medium"
-          >
-            Reject
-          </Button>
+        <Col span={8}>
+          <Row justify="end" gutter={[16,0]}>
+            <Col>
+              <Button
+                type="primary"
+                icon={<CheckOutlined size="large" />}
+                size="medium"
+              >
+                Accept
+              </Button>
+              </Col>
+              <Col>
+              <Button
+                type="primary"
+                danger
+                icon={<StopOutlined size="large" />}
+                size="medium"
+              >
+                Reject
+              </Button>
+            </Col>
+          </Row>
         </Col>
       </Row>
     </Card>

--- a/client/src/components/Request/Request.js
+++ b/client/src/components/Request/Request.js
@@ -1,26 +1,38 @@
 import "./Request.css";
 
-import { Avatar, Card, Button } from "antd";
+import { Avatar, Card, Button, Row, Col } from "antd";
 import { CheckOutlined, StopOutlined } from "@ant-design/icons";
 
 function Request(props) {
   return (
     <Card style={{ margin: 16 }}>
-      <Avatar src={props.user.avatarURL} size={64} />
-      {props.user.name + " wants to join " + props.group.name}
-      <Avatar src={props.group.avatarURL} size={64} />
-      <Button
-        icon={<CheckOutlined size="large" />}
-        size="medium"
-      >
-        Accept
-      </Button>
-      <Button
-        icon={<StopOutlined size="large" />}
-        size="medium"
-      >
-        Reject
-      </Button>
+      <Row align="middle" justify="space-around">
+        <Col>
+          <Avatar src={props.user.avatarURL} size={64} />
+          {props.user.name}
+        </Col>
+        <Col>
+          {" wants to join "}
+        </Col>
+        <Col>
+          {props.group.name}
+          <Avatar src={props.group.avatarURL} size={64} />
+        </Col>
+        <Col>
+          <Button
+            icon={<CheckOutlined size="large" />}
+            size="medium"
+          >
+            Accept
+          </Button>
+          <Button
+            icon={<StopOutlined size="large" />}
+            size="medium"
+          >
+            Reject
+          </Button>
+        </Col>
+      </Row>
     </Card>
   );
 }

--- a/client/src/components/RequestList/RequestList.js
+++ b/client/src/components/RequestList/RequestList.js
@@ -1,0 +1,44 @@
+import "./RequestList.css";
+
+import Request from "../Request/Request";
+
+function RequestList() {
+  const processedRequestData = [
+      {
+        user: {
+          user_id: "1-2-3-4",
+          avatarURL: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8cGVyc29ufGVufDB8fDB8fA%3D%3D&ixlib=rb-1.2.1&w=1000&q=80",
+          name: "Sally McGee"
+        },
+        group: {
+          group_id: "4-5-6-7",
+          avatarURL: "https://i0.wp.com/www.healthfitnessrevolution.com/wp-content/uploads/2016/09/iStock-119483507.jpg?resize=1024%2C683&ssl=1",
+          name: "People Who Eat Food"
+        }
+      },
+      {
+        user: {
+          user_id: "2-4-6-8",
+          avatarURL: "https://i2.wp.com/decider.com/wp-content/uploads/2020/06/adventure-time-distant-lands-bmo.jpg?quality=80&strip=all&ssl=1",
+          name: "Bea Mo"
+        },
+        group: {
+          group_id: "4-5-6-7",
+          avatarURL: "https://i0.wp.com/www.healthfitnessrevolution.com/wp-content/uploads/2016/09/iStock-119483507.jpg?resize=1024%2C683&ssl=1",
+          name: "People Who Eat Food"
+        }
+      }
+  ];
+
+  let requestList = processedRequestData.map((request) => (
+    <Request user={request.user} group={request.group} />
+  ));
+
+  return (
+    <div>
+      <ul>{requestList}</ul>
+    </div>
+  );
+}
+
+export default RequestList;

--- a/client/src/components/RequestView/RequestView.css
+++ b/client/src/components/RequestView/RequestView.css
@@ -1,0 +1,3 @@
+.container {
+  margin: 25px;
+}

--- a/client/src/components/RequestView/RequestView.js
+++ b/client/src/components/RequestView/RequestView.js
@@ -1,0 +1,32 @@
+import "./RequestView.css"
+
+import { Col, Divider, Row, Typography } from "antd";
+import { BellOutlined } from "@ant-design/icons";
+
+function RequestView() {
+  const { Title } = Typography;
+  return (
+    <div className="container">
+      <Row
+        style={{
+          marginLeft: "20px",
+        }}
+      >
+        <Col span={24}>
+          <Title level={2}>
+            <BellOutlined size="large" /> Requests
+          </Title>
+        </Col>
+      </Row>
+      <Divider
+        style={{
+          marginTop: "0",
+          borderWidth: 5,
+        }}
+      />
+      Requests go here
+    </div>
+  );
+}
+
+export default RequestView;

--- a/client/src/components/RequestView/RequestView.js
+++ b/client/src/components/RequestView/RequestView.js
@@ -2,6 +2,7 @@ import "./RequestView.css"
 
 import { Col, Divider, Row, Typography } from "antd";
 import { BellOutlined } from "@ant-design/icons";
+import RequestList from "../RequestList/RequestList";
 
 function RequestView() {
   const { Title } = Typography;
@@ -24,7 +25,7 @@ function RequestView() {
           borderWidth: 5,
         }}
       />
-      Requests go here
+      <RequestList />
     </div>
   );
 }


### PR DESCRIPTION
Frontiest front end for RequestView. Does not hook up to anything (even redux), just keeps its own dummy data for now.
Soliciting design-related feedback. I built it to house requests from any group the current user is in, but it could alternatively be a group-specific page with the group name/avatar in the upper right corner.

My initial thought is the "motivator" to go here - because we need to tell a user they have requests, they aren't going to get here on there own volition - is to put a Badge (https://ant.design/components/badge/) somewhere on the "Requests" nav menu item. (This is not implemented on this branch, but an idea I'd be happy to get feedback on.)

Request View:

![requiest-view](https://user-images.githubusercontent.com/30274095/124973047-e8b7e900-dfdf-11eb-957a-60f325cb66c6.gif)


