### PR TITLE
 🐛 Bug Fix: Prevent storing stale user into localStorage

### DIFF
--- a/backend/api/users.js
+++ b/backend/api/users.js
@@ -1,33 +1,33 @@
-import Group from "../models/Group.js";
-import User from "../models/User.js";
-import express from "express";
-import { v4 as uuidv4 } from "uuid";
+import Group from '../models/Group.js';
+import User from '../models/User.js';
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
 
 const router = express.Router();
 
-router.get("/", (req, res) => {
+router.get('/', (req, res) => {
   // Search the MongoDB
-  User.find({}, "-_id user_id email name avatarURL groups requestGroups")
+  User.find({}, '-_id user_id name avatarURL groups requestGroups')
     .then((users) => res.json(users))
     .catch((err) => console.log(err));
 });
 
-router.post("/login", (req, res) => {
+router.post('/login', (req, res) => {
   const { email, password } = req.body;
 
-  if (email === "") {
-    return res.status(400).send("Email field must be filled");
+  if (email === '') {
+    return res.status(400).send('Email field must be filled');
   }
 
-  if (password === "") {
-    return res.status(400).send("Password field must be filled");
+  if (password === '') {
+    return res.status(400).send('Password field must be filled');
   }
 
   // Find user by email
   User.findOne({ email }).then((user) => {
     // Check if user exists
     if (!user) {
-      return res.status(400).send("Email not found");
+      return res.status(400).send('Email not found');
     }
     // Check password
     const isMatch = user.password === password;
@@ -39,46 +39,44 @@ router.post("/login", (req, res) => {
           user_id: user.user_id,
           name: user.name,
           email: user.email,
-          avatarURL: user.avatarURL,
-          groups: user.groups,
         },
       });
     } else {
-      return res.status(400).send("Password incorrect");
+      return res.status(400).send('Password incorrect');
     }
   });
 });
 
-router.post("/register", (req, res) => {
+router.post('/register', (req, res) => {
   const { name, email, password, password2, avatarURL } = req.body;
 
-  if (name === "") {
-    return res.status(400).send("Name field must be filled");
+  if (name === '') {
+    return res.status(400).send('Name field must be filled');
   }
 
-  if (email === "") {
-    return res.status(400).send("Email field must be filled");
+  if (email === '') {
+    return res.status(400).send('Email field must be filled');
   }
 
-  if (password === "") {
-    return res.status(400).send("Password field must be filled");
+  if (password === '') {
+    return res.status(400).send('Password field must be filled');
   }
 
-  if (password2 === "") {
-    return res.status(400).send("Please confirm password");
+  if (password2 === '') {
+    return res.status(400).send('Please confirm password');
   }
 
-  if (avatarURL === "") {
-    return res.status(400).send("Avatar URL field must be filled");
+  if (avatarURL === '') {
+    return res.status(400).send('Avatar URL field must be filled');
   }
 
   if (password !== password2) {
-    return res.status(400).send("Password fields do not match");
+    return res.status(400).send('Password fields do not match');
   }
 
   User.findOne({ email: email }).then((user) => {
     if (user) {
-      return res.status(400).send("Email already exists");
+      return res.status(400).send('Email already exists');
     } else {
       const newUser = new User({
         user_id: uuidv4(),
@@ -92,34 +90,34 @@ router.post("/register", (req, res) => {
 
       newUser
         .save()
-        .then(() => res.send("User created successfully"))
+        .then(() => res.send('User created successfully'))
         .catch((err) =>
           res.status(400).json({
             error: err,
-            message: "Error creating user",
+            message: 'Error creating user',
           })
         );
     }
   });
 });
 
-router.post("/group/request", (req, res) => {
+router.post('/group/request', (req, res) => {
   const { user_id, group_id } = req.body;
   // Find group to join
   Group.findOne({ group_id }).then((group) => {
     // Check if group exists
     if (!group) {
-      return res.status(400).send("Group requested to join not found");
+      return res.status(400).send('Group requested to join not found');
     }
 
     // Check if user is not already in the group or request to join before
     User.findOne({ user_id }).then((user) => {
       if (user.groups.includes(group_id)) {
-        return res.status(400).send("Already a member of this group");
+        return res.status(400).send('Already a member of this group');
       }
 
       if (user.requestGroups.includes(group_id)) {
-        return res.status(400).send("Already requested to join this group");
+        return res.status(400).send('Already requested to join this group');
       }
 
       // Add group ID to user's requestGroups
@@ -130,28 +128,28 @@ router.post("/group/request", (req, res) => {
   });
 });
 
-router.post("/group/accept", (req, res) => {
+router.post('/group/accept', (req, res) => {
   const { my_user_id, other_user_id, group_id } = req.body;
 
   // Find group
   Group.findOne({ group_id }).then((group) => {
     // Check if group exists
     if (!group) {
-      return res.status(400).send("Group does not exist");
+      return res.status(400).send('Group does not exist');
     }
   });
 
   // Check if current user is part of group
   User.findOne({ user_id: my_user_id }).then((user) => {
     if (!user) {
-      return res.status(400).send("Cannot verify current user");
+      return res.status(400).send('Cannot verify current user');
     }
 
     if (!user.groups.includes(group_id)) {
       return res
         .status(400)
         .send(
-          "Not authorized to accept users into a group you are not a member of"
+          'Not authorized to accept users into a group you are not a member of'
         );
     }
   });
@@ -159,12 +157,12 @@ router.post("/group/accept", (req, res) => {
   // Check if other user exists and has requested to join group
   User.findOne({ user_id: other_user_id }).then((user) => {
     if (!user) {
-      return res.status(400).send("Cannot find other user");
+      return res.status(400).send('Cannot find other user');
     }
 
     // Check if other user is already a member of this group
     if (user.groups.includes(group_id)) {
-      return res.status(400).send("Other user is already part of this group");
+      return res.status(400).send('Other user is already part of this group');
     }
 
     if (user.requestGroups.includes(group_id)) {
@@ -186,33 +184,33 @@ router.post("/group/accept", (req, res) => {
     } else {
       return res
         .status(400)
-        .send("Other user has not requested to join this group");
+        .send('Other user has not requested to join this group');
     }
   });
 });
 
-router.post("/group/decline", (req, res) => {
+router.post('/group/decline', (req, res) => {
   const { my_user_id, other_user_id, group_id } = req.body;
 
   // Find group
   Group.findOne({ group_id }).then((group) => {
     // Check if group exists
     if (!group) {
-      return res.status(400).send("Group does not exist");
+      return res.status(400).send('Group does not exist');
     }
   });
 
   // Check if current user is part of group
   User.findOne({ user_id: my_user_id }).then((user) => {
     if (!user) {
-      return res.status(400).send("Cannot verify current user");
+      return res.status(400).send('Cannot verify current user');
     }
 
     if (!user.groups.includes(group_id)) {
       return res
         .status(400)
         .send(
-          "Not authorized to accept users into a group you are not a member of"
+          'Not authorized to accept users into a group you are not a member of'
         );
     }
   });
@@ -220,12 +218,12 @@ router.post("/group/decline", (req, res) => {
   // Check if other user exists and has requested to join group
   User.findOne({ user_id: other_user_id }).then((user) => {
     if (!user) {
-      return res.status(400).send("Cannot find other user");
+      return res.status(400).send('Cannot find other user');
     }
 
     // Check if other user is already a member of this group
     if (user.groups.includes(group_id)) {
-      return res.status(400).send("Other user is already part of this group");
+      return res.status(400).send('Other user is already part of this group');
     }
 
     if (user.requestGroups.includes(group_id)) {
@@ -239,7 +237,7 @@ router.post("/group/decline", (req, res) => {
     } else {
       return res
         .status(400)
-        .send("Other user has not requested to join this group");
+        .send('Other user has not requested to join this group');
     }
   });
 });

--- a/client/src/components/Navigation/MobileNavBar/MobileNavBar.js
+++ b/client/src/components/Navigation/MobileNavBar/MobileNavBar.js
@@ -1,19 +1,23 @@
-import "./MobileNavBar.css";
+import './MobileNavBar.css';
 
-import { Button, Drawer, Dropdown, Menu } from "antd";
-import { LogoutOutlined, UserOutlined } from "@ant-design/icons";
-import { useDispatch, useSelector } from "react-redux";
+import { Button, Drawer, Dropdown, Menu } from 'antd';
+import { LogoutOutlined, UserOutlined } from '@ant-design/icons';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { Link } from "react-router-dom";
-import { MenuOutlined } from "@ant-design/icons";
-import logo from "../../../assets/logo.png";
-import { logoutUser } from "../../../redux/actions/userActions";
-import { useState } from "react";
+import { Link } from 'react-router-dom';
+import { MenuOutlined } from '@ant-design/icons';
+import logo from '../../../assets/logo.png';
+import { logoutUser } from '../../../redux/actions/userActions';
+import { useState } from 'react';
 
 const MobileNavBar = ({ menu }) => {
   const [visible, setVisible] = useState(false);
-  const userAvatarURL = useSelector((state) => state.users.user.avatarURL);
+  const allUsers = useSelector((state) => state.users.allUsers);
+
+  const currentUserID = useSelector((state) => state.users.user.user_id);
   const userName = useSelector((state) => state.users.user.name);
+  const currentUser = allUsers.find((user) => user.user_id === currentUserID);
+
   const dispatch = useDispatch();
 
   function handleLogout() {
@@ -47,7 +51,7 @@ const MobileNavBar = ({ menu }) => {
         onClose={() => setVisible(false)}
         visible={visible}
         drawerStyle={{
-          backgroundColor: "#041527",
+          backgroundColor: '#041527',
         }}
       >
         {menu}
@@ -58,9 +62,13 @@ const MobileNavBar = ({ menu }) => {
         </a>
         Places
       </span>
-      <Dropdown overlay={profileMenu} trigger={["click"]}>
+      <Dropdown overlay={profileMenu} trigger={['click']}>
         <span className="profilepic">
-          <img src={userAvatarURL} className="profilepic" alt="profile pic" />
+          <img
+            src={currentUser.avatarURL}
+            className="profilepic"
+            alt="profile pic"
+          />
         </span>
       </Dropdown>
     </nav>

--- a/client/src/components/Navigation/MobileNavBar/MobileNavBar.js
+++ b/client/src/components/Navigation/MobileNavBar/MobileNavBar.js
@@ -64,11 +64,13 @@ const MobileNavBar = ({ menu }) => {
       </span>
       <Dropdown overlay={profileMenu} trigger={['click']}>
         <span className="profilepic">
-          <img
-            src={currentUser.avatarURL}
-            className="profilepic"
-            alt="profile pic"
-          />
+          {currentUser && (
+            <img
+              src={currentUser.avatarURL}
+              className="profilepic"
+              alt="profile pic"
+            />
+          )}
         </span>
       </Dropdown>
     </nav>


### PR DESCRIPTION
 - 🐛 Bug Fix: Prevent storing stale user into localStorage
   - After successfull login, only storing:
     - `user_id`, `name`, and `email`

To get other info about current user, I look for their user (using their `user_id`) in the allUsers state. Thats always fetched and contains up-to-date info on their groups, request groups, etc. 