### PR TITLE
Just Add Category

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,8 @@
     "antd": "^4.16.1",
     "axios": "^0.21.1",
     "craco-less": "^1.17.1",
+    "emoji-mart": "^3.0.1",
+    "grapheme-splitter": "^1.0.4",
     "is-empty": "^1.2.0",
     "jwt-decode": "^3.1.2",
     "react": "^17.0.2",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import {
 import { logoutUser, setCurrentUser } from './redux/actions/userActions';
 import { useDispatch, useSelector } from 'react-redux';
 
+import AddCategory from './components/AddCategory/AddCategory';
 import AddPlace from './components/AddPlace/AddPlace';
 import AddReview from './components/AddReview/AddReview';
 import CategoryView from './components/CategoryView/CategoryView';
@@ -39,6 +40,7 @@ function App() {
   const RegisterWithRouter = withRouter(Register);
   const CreateGroupWithRouter = withRouter(CreateGroup);
   const ManageGroupWithRouter = withRouter(ManageGroup);
+  const AddCategoryWithRouter = withRouter(AddCategory);
   const AddPlaceWithRouter = withRouter(AddPlace);
   const AddReviewWithRouter = withRouter(AddReview);
   const isAuthenticated = useSelector((state) => state.users.isAuthenticated);
@@ -83,6 +85,11 @@ function App() {
                 exact
                 path="/creategroup"
                 component={CreateGroupWithRouter}
+              />
+              <PrivateRoute
+                exact
+                path="/addcategory"
+                component={AddCategoryWithRouter}
               />
               <PrivateRoute
                 exact

--- a/client/src/components/AddCategory/AddCategory.css
+++ b/client/src/components/AddCategory/AddCategory.css
@@ -1,0 +1,3 @@
+.currentCategory {
+  text-align: right;
+}

--- a/client/src/components/AddCategory/AddCategory.js
+++ b/client/src/components/AddCategory/AddCategory.js
@@ -16,10 +16,10 @@ function AddCategory(props) {
   const splitter = new GraphemeSplitter();
   const currentGroup = useSelector((state) => state.groups.currentGroupID);
   const [isCustomCriteria, setIsCustomCriteria] = useState(false);
-  const [numberOfCriteria, setNumberOfCriteria] = useState(1);
+  const [numberOfCriteria, setNumberOfCriteria] = useState(2);
   const [emojiPickerVisible, setEmojiPickerVisible] = useState(false);
 
-  const defaultCriteria = ["Coolness", "Flavour", "Space", "Quality", "Trendiness"];
+  const defaultCriteria = ["Coolness", "Quality", "Flavour", "Comfort", "Size"];
   const useWeights = false;
 
   function handleChange() {
@@ -82,7 +82,7 @@ function AddCategory(props) {
             layout="vertical"
             size="large"
             onChange={handleChange}
-            initialValues={{ criteria: [{criterion: defaultCriteria[0], weight: 5}] }}
+            initialValues={{ criteria: [{criterion: defaultCriteria[0]}, {criterion: defaultCriteria[1]}] }}
           >
             <Form.Item name="name_singular" label="Name for one place">
               <Input placeholder="Beach" />
@@ -121,9 +121,6 @@ function AddCategory(props) {
                         }}
                         style={{paddingTop:"18px"}}
                       />}
-                      {console.log("name: " + name)}
-                      {console.log("fieldKey: " + fieldKey)}
-                      {console.log("key: "+ key)}
                      </Col>
                      <Col span={11}>
                        <Form.Item
@@ -132,7 +129,7 @@ function AddCategory(props) {
                          label="Criterion"
                          fieldKey={[fieldKey, 'criterion']}
                        >
-                         <Input placeholder="Coolness" />
+                         <Input/>
                        </Form.Item>
                       </Col>
                       <Col span={11}>
@@ -149,16 +146,13 @@ function AddCategory(props) {
                     :
                     <Row gutter={[7,7]} align="middle" key={key} >
                       <Col span={2}>
-                       {(name > 0) && <MinusCircleOutlined
+                       {(name > 1) && <MinusCircleOutlined
                          onClick={() => {
                            setNumberOfCriteria(numberOfCriteria - 1);
                            remove(name);
                          }}
                          style={{paddingTop:"18px"}}
                        />}
-                       {console.log("name: " + name)}
-                       {console.log("fieldKey: " + fieldKey)}
-                       {console.log("key: "+ key)}
                       </Col>
                       <Col span={22}>
                         <Form.Item
@@ -167,7 +161,7 @@ function AddCategory(props) {
                           label="Criterion"
                           fieldKey={[fieldKey, 'criterion']}
                         >
-                          <Input placeholder="Coolness" />
+                          <Input placeholder={defaultCriteria[name%6]} />
                         </Form.Item>
                        </Col>
                      </Row>

--- a/client/src/components/AddCategory/AddCategory.js
+++ b/client/src/components/AddCategory/AddCategory.js
@@ -1,0 +1,181 @@
+import './AddCategory.css';
+
+import { Button, Col, Divider, Form, Input, Row, Typography, Switch, InputNumber, Modal } from 'antd';
+import { MinusCircleOutlined, PlusOutlined, SmileOutlined } from '@ant-design/icons';
+import { Picker } from 'emoji-mart';
+import GraphemeSplitter from "grapheme-splitter";
+import 'emoji-mart/css/emoji-mart.css'
+import { useDispatch, useSelector } from 'react-redux';
+import { useState } from 'react';
+import { addCategory } from '../../redux/actions/categoryActions';
+
+function AddCategory(props) {
+  const { Title } = Typography;
+  const [form] = Form.useForm();
+  const dispatch = useDispatch();
+  const splitter = new GraphemeSplitter();
+  const currentGroup = useSelector((state) => state.groups.currentGroupID);
+  const [isCustomCriteria, setIsCustomCriteria] = useState(false);
+  const [numberOfCriteria, setNumberOfCriteria] = useState(1);
+  const [emojiPickerVisible, setEmojiPickerVisible] = useState(false);
+
+  const defaultCriteria = ["Coolness", "Flavour", "Space", "Quality", "Trendiness"];
+
+  function handleChange() {
+    console.log("changed");
+    let emojiField = form.getFieldValue('emoji');
+    if (emojiField) {
+      let graphemes = splitter.splitGraphemes(emojiField);
+      let lastEmoji = "";
+      graphemes.forEach((item) => {
+        if (item.match(/\p{Emoji_Presentation}/gu)) {
+          lastEmoji = item;
+        }
+      });
+      form.setFieldsValue({emoji: lastEmoji});
+    }
+  }
+
+  function handleAddCategory() {
+    let name = form.getFieldValue('name_plural');
+    let name_singular = form.getFieldValue('name_singular');
+    let emoji = form.getFieldValue('emoji');
+    let criteria= form.getFieldValue('criteria');
+    let newCategory = {
+      name: name,
+      name_singluar: name_singular,
+      emoji: emoji,
+      criteria: criteria
+    };
+    console.log(newCategory);
+    if (false) {
+      dispatch(addCategory(newCategory, props.history));
+    }
+    form.resetFields();
+  }
+  return (
+    <Col className="container">
+      <Row justify="center">
+        <Col lg={12} md={12} sm={12}>
+          <Title level={2}>Add Cateogry</Title>
+        </Col>
+        <Col lg={0} md={0} sm={0} xs={24}></Col>
+        <Col lg={12} md={12} sm={12} className="currentCategory">
+          <h2>
+             {currentGroup.name}
+          </h2>
+        </Col>
+      </Row>
+      <Divider
+        style={{
+          borderWidth: 5,
+        }}
+      />
+      <Row justify="center">
+        <Col lg={12} md={12} sm={12}>
+          <Form
+            className="form"
+            form={form}
+            layout="vertical"
+            size="large"
+            onChange={handleChange}
+            initialValues={{ criteria: [{criterion: defaultCriteria[0], weight: 5}] }}
+          >
+            <Form.Item name="name_singular" label="Name for one place">
+              <Input placeholder="Beach" />
+            </Form.Item>
+            <Form.Item name="name_plural" label="Name for multiple places">
+              <Input placeholder="Beaches" />
+            </Form.Item>
+            <Form.Item label="Emoji">
+              <Form.Item name="emoji">
+                <Input
+                  size="large"
+                  suffix={<SmileOutlined onClick={() => setEmojiPickerVisible(true)}/>}
+                />
+              </Form.Item>
+              <Modal visible={emojiPickerVisible} footer={null} onOk={()=>{}} onCancel={()=>{setEmojiPickerVisible(false)}}>
+                <Picker title='Select emoji' emoji='pin' onSelect={emoji => {
+                  form.setFieldsValue({emoji: emoji.native});
+                  setEmojiPickerVisible(false);
+                }} />
+              </Modal>
+            </Form.Item>
+            <Form.Item label="Use custom criteria?" name="customCriteriaSwitch" valuePropName="checked">
+              <Switch defaultChecked={false} onChange={(value) => {setIsCustomCriteria(value)}} />
+            </Form.Item>
+            {isCustomCriteria &&
+            <Form.List name="criteria">
+             {(fields, { add, remove }) => (
+               <>
+                 {fields.map(({ key, name, fieldKey, ...restField }) => (
+                   <Row gutter={[7,7]} align="middle" key={key} >
+                     <Col span={2}>
+                      {(name > 0) && <MinusCircleOutlined
+                        onClick={() => {
+                          setNumberOfCriteria(numberOfCriteria - 1);
+                          remove(name);
+                        }}
+                        style={{paddingTop:"18px"}}
+                      />}
+                      {console.log("name: " + name)}
+                      {console.log("fieldKey: " + fieldKey)}
+                      {console.log("key: "+ key)}
+                     </Col>
+                     <Col span={11}>
+                       <Form.Item
+                         {...restField}
+                         name={[name, 'criterion']}
+                         label="Criterion"
+                         fieldKey={[fieldKey, 'criterion']}
+                       >
+                         <Input placeholder="Coolness" />
+                       </Form.Item>
+                      </Col>
+                      <Col span={11}>
+                       <Form.Item
+                         {...restField}
+                         name={[name, 'weight']}
+                         label="Weight (1-10)"
+                         fieldKey={[fieldKey, 'weight']}
+                       >
+                          <InputNumber min={1} max={10} formatter={value => Math.round(value)} />
+                       </Form.Item>
+                      </Col>
+                    </Row>
+                 ))}
+                 {(numberOfCriteria < 5) && <Form.Item>
+                    <Button
+                      type="dashed"
+                      onClick={() => {
+                        setNumberOfCriteria(numberOfCriteria + 1);
+                        add({ criterion: defaultCriteria[numberOfCriteria%5], weight: 5 });
+                      }}
+                      block icon={<PlusOutlined />}
+                    >
+                     Add criterion
+                   </Button>
+                 </Form.Item>}
+               </>
+             )}
+           </Form.List>}
+          </Form>
+        </Col>
+      </Row>
+      <Row justify="center">
+        <Col>
+          <Button
+            onClick={handleAddCategory}
+            className="button"
+            type="primary"
+            size="large"
+          >
+            Submit
+          </Button>
+        </Col>
+      </Row>
+    </Col>
+  );
+}
+
+export default AddCategory;

--- a/client/src/components/AddCategory/AddCategory.js
+++ b/client/src/components/AddCategory/AddCategory.js
@@ -42,11 +42,13 @@ function AddCategory(props) {
     let name_singular = form.getFieldValue('name_singular');
     let emoji = form.getFieldValue('emoji');
     let criteria= form.getFieldValue('criteria');
+    let use_custom_criteria = form.getFieldValue('use_custom_criteria');
+
     let newCategory = {
       name: name,
       name_singluar: name_singular,
       emoji: emoji,
-      criteria: criteria
+      criteria: use_custom_criteria? criteria : [],
     };
     console.log(newCategory);
     if (false) {
@@ -102,7 +104,7 @@ function AddCategory(props) {
                 }} />
               </Modal>
             </Form.Item>
-            <Form.Item label="Use custom criteria?" name="customCriteriaSwitch" valuePropName="checked">
+            <Form.Item label="Use custom criteria?" name="use_custom_criteria" valuePropName="checked">
               <Switch defaultChecked={false} onChange={(value) => {setIsCustomCriteria(value)}} />
             </Form.Item>
             {isCustomCriteria &&

--- a/client/src/components/AddCategory/AddCategory.js
+++ b/client/src/components/AddCategory/AddCategory.js
@@ -20,6 +20,7 @@ function AddCategory(props) {
   const [emojiPickerVisible, setEmojiPickerVisible] = useState(false);
 
   const defaultCriteria = ["Coolness", "Flavour", "Space", "Quality", "Trendiness"];
+  const useWeights = false;
 
   function handleChange() {
     console.log("changed");
@@ -109,7 +110,7 @@ function AddCategory(props) {
              {(fields, { add, remove }) => (
                <>
                  {fields.map(({ key, name, fieldKey, ...restField }) => (
-                   <Row gutter={[7,7]} align="middle" key={key} >
+                   useWeights ? <Row gutter={[7,7]} align="middle" key={key} >
                      <Col span={2}>
                       {(name > 0) && <MinusCircleOutlined
                         onClick={() => {
@@ -143,6 +144,31 @@ function AddCategory(props) {
                        </Form.Item>
                       </Col>
                     </Row>
+                    :
+                    <Row gutter={[7,7]} align="middle" key={key} >
+                      <Col span={2}>
+                       {(name > 0) && <MinusCircleOutlined
+                         onClick={() => {
+                           setNumberOfCriteria(numberOfCriteria - 1);
+                           remove(name);
+                         }}
+                         style={{paddingTop:"18px"}}
+                       />}
+                       {console.log("name: " + name)}
+                       {console.log("fieldKey: " + fieldKey)}
+                       {console.log("key: "+ key)}
+                      </Col>
+                      <Col span={22}>
+                        <Form.Item
+                          {...restField}
+                          name={[name, 'criterion']}
+                          label="Criterion"
+                          fieldKey={[fieldKey, 'criterion']}
+                        >
+                          <Input placeholder="Coolness" />
+                        </Form.Item>
+                       </Col>
+                     </Row>
                  ))}
                  {(numberOfCriteria < 5) && <Form.Item>
                     <Button

--- a/client/src/components/GroupView/GroupView.css
+++ b/client/src/components/GroupView/GroupView.css
@@ -11,3 +11,7 @@
   margin-top: 10px;
   margin-bottom: 10px;
 }
+
+.addCategoryLink {
+  margin-left: 15px;
+}

--- a/client/src/components/GroupView/GroupView.js
+++ b/client/src/components/GroupView/GroupView.js
@@ -4,7 +4,7 @@ import { Avatar, Button, Col, Divider, Row, Typography } from "antd";
 
 import CategoryList from "../CategoryList/CategoryList";
 import { Link } from "react-router-dom";
-import { UserOutlined } from "@ant-design/icons";
+import { UserOutlined, PlusOutlined } from '@ant-design/icons';
 import { useSelector } from "react-redux";
 
 function GroupView() {
@@ -51,6 +51,13 @@ function GroupView() {
           borderWidth: 5,
         }}
       />
+      <Link
+        to="/addCategory"
+      >
+        <Button type="primary" icon={<PlusOutlined />} size="large">
+          Add Category
+        </Button>
+      </Link>
       <CategoryList />
     </Col>
   );

--- a/client/src/components/GroupView/GroupView.js
+++ b/client/src/components/GroupView/GroupView.js
@@ -1,11 +1,10 @@
 import "./GroupView.css";
 
 import { Avatar, Button, Col, Divider, Row, Typography } from "antd";
-
-import CategoryList from "../CategoryList/CategoryList";
 import { Link } from "react-router-dom";
 import { UserOutlined, PlusOutlined } from '@ant-design/icons';
 import { useSelector } from "react-redux";
+import CategoryList from "../CategoryList/CategoryList";
 
 function GroupView() {
   const { Title } = Typography;

--- a/client/src/components/GroupView/GroupView.js
+++ b/client/src/components/GroupView/GroupView.js
@@ -53,6 +53,7 @@ function GroupView() {
       />
       <Link
         to="/addCategory"
+        class="addCategoryLink"
       >
         <Button type="primary" icon={<PlusOutlined />} size="large">
           Add Category

--- a/client/src/components/GroupView/GroupView.js
+++ b/client/src/components/GroupView/GroupView.js
@@ -52,7 +52,7 @@ function GroupView() {
       />
       <Link
         to="/addCategory"
-        class="addCategoryLink"
+        className="addCategoryLink"
       >
         <Button type="primary" icon={<PlusOutlined />} size="large">
           Add Category

--- a/client/src/redux/actions/categoryActions.js
+++ b/client/src/redux/actions/categoryActions.js
@@ -1,10 +1,26 @@
 import axios from 'axios';
+import { message } from 'antd';
 
 export const getCategories = () => async (dispatch) => {
   try {
     const categoriesResponse = await axios.get('/api/categories');
     const categories = categoriesResponse.data;
     dispatch(setCategories(categories));
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+export const addCategory = (newCategory, history) => async (dispatch) => {
+  try {
+    const loading = message.loading('Creating category..', 0);
+    const newCategoryResponse = await axios.post('/api/categories', newCategory);
+    const newCategoryFull = await newCategoryResponse.data;
+    loading();
+    await dispatch(getCategories());
+    await dispatch(setCurrentCategory(newCategoryFull.category_id));
+    history.push('/categoryview');
+    message.success('New category created!');
   } catch (err) {
     console.log(err);
   }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1192,6 +1192,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.0.0":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
@@ -4439,6 +4446,14 @@ emittery@^0.7.1:
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
+emoji-mart@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-3.0.1.tgz#9ce86706e02aea0506345f98464814a662ca54c6"
+  integrity sha512-sxpmMKxqLvcscu6mFn9ITHeZNkGzIvD0BSNFE/LJESPbCA8s1jM6bCDPjWbV31xHq7JXaxgpHxLB54RCbBZSlg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    prop-types "^15.6.0"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz"
@@ -5484,6 +5499,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.6"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -9041,7 +9061,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
Add Category component.

- Linked from GroupView above CategoryList
- Emoji field restricts input to one emoji, but will allow this emoji to be a multi-character emoji eg. one with skin tone, gender or regional modifiers (using GraphemeSplitter)
-Smile icon at end of emoji field opens emoji picker (EmojiMart) in modal popup, so desktop users can pick an emoji
-(Field is also a text box that will only accept emoji, so mobile users can use their keyboard)
-Custom criteria switch controls whether custom criteria are used
-Default is two criteria, neither can be removed (because why bother with custom criteria if there is only one?)
-If <=5 criteria total, user can add additional criteria fields with button
-Criteria fields 3-5 have minus icon and can be optionally removed

![add-category](https://user-images.githubusercontent.com/30274095/127372806-95eb7acd-584a-4cde-a697-312f6941365c.gif)


-Add Category action is created but back end is not fully connected and form is currently disabled