### PR TITLE
🐛 Fix Node failing to start bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node backend/server.js",
     "server": "nodemon --watch backend backend/server.js",
     "client": "cd client && npm start",
-    "dev": "concurrently \"npm run server\" \"npm run client\"",
+    "dev": "killall node & concurrently \"npm run server\" \"npm run client\"",
     "heroku-postbuild": "cd client && yarn install && yarn build",
     "first-install": "yarn install && cd client && yarn install"
   },


### PR DESCRIPTION
Fixes the issue where sometimes **node** stays running and continues hogging the port so new instances cant run.
`yarn dev` now first kills any running node servers before starting up.

idk if this works on windows environments. But 100% should work on mac. @laurarodgers let me know how things go for you. 