### PR TITLE
⚡️Remove deployment delays (not needed anymore)

### DIFF
--- a/.github/workflows/heroku-deploy-production.yml
+++ b/.github/workflows/heroku-deploy-production.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Sleep for 12 minutes
-        run: sleep 12m
-        shell: bash
       - name: Deploy Production
         uses: akhileshns/heroku-deploy@v3.12.12
         with:

--- a/.github/workflows/heroku-deploy-staging.yml
+++ b/.github/workflows/heroku-deploy-staging.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Sleep for 12 minutes
-        run: sleep 12m
-        shell: bash
       - name: Deploy Staging
         uses: akhileshns/heroku-deploy@v3.12.12
         with:


### PR DESCRIPTION
✅Found out that if I “verify” my heroku account. Simply by providing a credit card. Won’t actually cost anything. They’ll allow 10 concurrent builds at a time. So no need to delay it anymore.

⚡️Also, verification gave us 450 extra monthly hours for the dyno running the app. So I’m using http://kaffeine.herokuapp.com/ to keep our production app always awake and ready to respond! 

- no more delays when visiting https://places-cpsc455.herokuapp.com/ for the first time in a while 