### PR TITLE
🐛 Fix Redux Dev Tools causing crashes on some browsers

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "redux": "^4.1.1",
+    "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.3.0",
     "web-vitals": "^2.1.0"
   },

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -1,6 +1,7 @@
-import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 
 import categoryReducer from './reducers/categoryReducer';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import groupReducer from './reducers/groupReducer';
 import placeReducer from './reducers/placeReducer';
 import reviewReducer from './reducers/reviewReducer';
@@ -15,14 +16,6 @@ const allReducer = combineReducers({
   reviews: reviewReducer
 });
 
-const store = createStore(
-  allReducer,
-  compose(
-    applyMiddleware(thunk),
-    window.navigator.userAgent.includes('Chrome')
-      ? window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-      : compose
-  )
-);
+const store = createStore(allReducer, composeWithDevTools(applyMiddleware(thunk)));
 
 export default store;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9922,6 +9922,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-devtools-extension@^2.13.9:
+  version "2.13.9"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz#6b764e8028b507adcb75a1cae790f71e6be08ae7"
+  integrity sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
Was having redux dev tools cause crashes in some browsers and when using incognito mode in chrome. From this [thread](https://github.com/reduxjs/redux/issues/2359), I learned about a super useful package called [redux-devtools-extension](https://www.npmjs.com/package/redux-devtools-extension) that handles and this and loads Redux dev tools properly across all browsers and disables it in production. 